### PR TITLE
fix: add npm install

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           node-version-file: './.node-version'
 
+      - name: Install node modules
+        shell: bash
+        run: npm ci
+
       - name: Assume Role
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/cd.yml` file. The change adds a step to install Node.js modules using `npm ci` in the continuous deployment workflow.